### PR TITLE
Create new repository for hosting the WindowBuilder website sources

### DIFF
--- a/otterdog/eclipse-windowbuilder.jsonnet
+++ b/otterdog/eclipse-windowbuilder.jsonnet
@@ -79,5 +79,16 @@ orgs.newOrg('eclipse-windowbuilder') {
         enabled: false,
       },
     },
+    orgs.newRepo('windowbuilder-website-source') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "master",
+      delete_branch_on_merge: false,
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+      workflows+: {
+        enabled: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
With the deprecation of PHP within the current year, we need to migrate HTML or something similar. Hugo is one of the proposed alternative, which requires its sources to be hosted separately from the actual website.

Issue:
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1934

Hugo template:
https://gitlab.eclipse.org/eclipsefdn/it/webdev/hugo-eclipsefdn-website-boilerplate#how-to-build-my-projects-website-with-jenkins

"Old" website:
https://github.com/eclipse-windowbuilder/windowbuilder-website/