### PR TITLE
Create new GitHub repository for hosting SVG images and icons

### DIFF
--- a/otterdog/eclipse-windowbuilder.jsonnet
+++ b/otterdog/eclipse-windowbuilder.jsonnet
@@ -82,5 +82,15 @@ orgs.newOrg('eclipse-windowbuilder') {
         enabled: false,
       },
     },
+    orgs.newRepo('windowbuilder-images') {
+      allow_merge_commit: true,
+      default_branch: "master",
+      delete_branch_on_merge: false,
+      description: "Eclipse Windowbuilder SVG Images and Icons",
+      web_commit_signoff_required: false,
+      workflows+: {
+        enabled: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
For the WindowBuilder project, we only care about the exported PNG images. But in order to easily create those images in arbitrary resolutions, we should also preserve the source files.