### PR TITLE
Revert "Create new GitHub repository for hosting SVG images and icons

### DIFF
--- a/otterdog/eclipse-windowbuilder.jsonnet
+++ b/otterdog/eclipse-windowbuilder.jsonnet
@@ -82,15 +82,5 @@ orgs.newOrg('eclipse-windowbuilder') {
         enabled: false,
       },
     },
-    orgs.newRepo('windowbuilder-images') {
-      allow_merge_commit: true,
-      default_branch: "master",
-      delete_branch_on_merge: false,
-      description: "Eclipse Windowbuilder SVG Images and Icons",
-      web_commit_signoff_required: false,
-      workflows+: {
-        enabled: false,
-      },
-    },
   ],
 }


### PR DESCRIPTION
(#4)"

This reverts commit 67428cada8792b6c4ee2201898da77c2696a1577. Keeping the SVG files directly in the base repository decreases the maintenance work, rendering the windowbuilder-images repository unused.

Given that it is effectively empty, it should be safe to simply delete it.