### PR TITLE
Use default visibility for GitLab IPLab token

### DIFF
--- a/otterdog/eclipse-windowbuilder.jsonnet
+++ b/otterdog/eclipse-windowbuilder.jsonnet
@@ -36,7 +36,6 @@ orgs.newOrg('eclipse-windowbuilder') {
         "windowbuilder"
       ],
       value: "********",
-      visibility: "selected",
     },
   ],
   _repositories+:: [

--- a/otterdog/eclipse-windowbuilder.jsonnet
+++ b/otterdog/eclipse-windowbuilder.jsonnet
@@ -32,9 +32,6 @@ orgs.newOrg('eclipse-windowbuilder') {
   ],
   secrets+: [
     orgs.newOrgSecret('GITLAB_API_TOKEN') {
-      selected_repositories+: [
-        "windowbuilder"
-      ],
       value: "********",
     },
   ],


### PR DESCRIPTION
Whenever a pull-request is created by dependabot, the license check fails with a 401 - Unauthorized. Given that the same check works for normal committers, it is likely that the token is still valid, just inaccessible.

See my PR: https://github.com/eclipse-windowbuilder/windowbuilder/actions/runs/10548647503/job/29575348859

> Error:  Failed to execute goal org.eclipse.dash:license-tool-plugin:1.1.1-SNAPSHOT:license-check (default-cli) on project org.eclipse.wb.root: Some dependencies must be vetted. -> [Help 1]

And see one from dependabot: https://github.com/eclipse-windowbuilder/windowbuilder/actions/runs/10660680894/job/29575430345

> [ERROR] Failed to execute goal org.eclipse.dash:license-tool-plugin:1.1.1-SNAPSHOT:license-check (default-cli) on project org.eclipse.wb.root: Execution default-cli of goal org.eclipse.dash:license-tool-plugin:1.1.1-SNAPSHOT:license-check failed: org.gitlab4j.api.GitLabApiException: 401 Unauthorized -> [Help 1]